### PR TITLE
Switch Over to Message API and update pyproject.toml

### DIFF
--- a/llm_bedrock_anthropic.py
+++ b/llm_bedrock_anthropic.py
@@ -17,10 +17,12 @@ def register_models(register):
         BedrockClaude("anthropic.claude-instant-v1"),
       aliases=("bedrock-claude-instant", 'bci'),
     )
-    register(BedrockClaude("anthropic.claude-v1"), aliases=("bedrock-claude-v1",))
-    register(BedrockClaude("anthropic.claude-v2"), aliases=('bedrock-claude-v2.0'))
+    register(BedrockClaude("anthropic.claude-v2"), aliases=('bedrock-claude-v2-0'))  # . doesn't seem to work as an alias
     register(BedrockClaude("anthropic.claude-v2:1"),
              aliases=('bedrock-claude-v2.1', 'bedrock-claude-v2', 'bedrock-claude', 'bc'))
+    register(BedrockClaude("anthropic.claude-3-sonnet-20240229-v1:0"),
+             aliases=('bedrock-claude-v3-sonnet', 'bedrock-claude-v3-sonnet', 'bedrock-claude-sonnet',
+                      'bedrock-sonnet', 'bc'))
 
 
 class BedrockClaude(llm.Model):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ classifiers = [
 
 dependencies = [
     "llm",
-    "boto3 >= 1.28.60",
+    "boto3 >=1.34.55",
+    "pydantic >= 2.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
I worked on this without seeing Tei's commit; apologies but I think this solution is cleaner since it completely removes the completions API. We also:

1. Update pyproject.toml 
2. Remove no longer supported models. 