### PR TITLE
Update 3.5 Sonnet v2 model id

### DIFF
--- a/llm_bedrock_anthropic.py
+++ b/llm_bedrock_anthropic.py
@@ -55,7 +55,7 @@ def register_models(register):
         ),
     )
     register(
-        BedrockClaude("anthropic.claude-3-5-sonnet-20241022-v2:0"),
+        BedrockClaude("us.anthropic.claude-3-5-sonnet-20241022-v2:0"),
         aliases=(
             "bedrock-claude-v3.5-sonnet-v2",
             "bedrock-claude-sonnet-v2",


### PR DESCRIPTION
Adding `us.` prefix to use inference profile for Claude 3.5 Sonnet v2.

Cross region inference is recommended for improved resilience and availability, see https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html

Fixes [issue 20](https://github.com/sblakey/llm-bedrock-anthropic/issues/20)