### PR TITLE
Added support for Claude Sonnet v3.7

### DIFF
--- a/llm_bedrock_anthropic.py
+++ b/llm_bedrock_anthropic.py
@@ -96,7 +96,15 @@ def register_models(register):
             "bedrock-haiku",
             "bh",
         ),
-    )    
+    )
+    register(
+        BedrockClaude("us.anthropic.claude-3-7-sonnet-20250219-v1:0"),
+        aliases=(
+            "bedrock-claude-v3.7-sonnet",
+            "bedrock-claude-sonnet-v3.7",
+            "bc-v3.7",
+        ),
+    )
 
 
 class BedrockClaude(llm.Model):


### PR DESCRIPTION
Adds support for the Claude 3.7 model: anthropic.claude-3-7-sonnet-20250219-v1:0 using the us inference Bedrock endpoints.

Usage: 
```
# llm -m bc-v3.7 "Who are you?"

I'm Claude, an AI assistant created by Anthropic to be helpful, harmless, and honest. I can have conversations, answer questions, assist with various tasks like writing and analysis, and generate different kinds of content based on your requests. I aim to be thoughtful, ethical, and straightforward in my interactions. I don't have a physical form, personal experiences, or consciousness - I function as an AI system designed to communicate through text. How can I help you today?
```

To set as the default model:
```
llm models default bc-v3.7
```
